### PR TITLE
feat: DNS format desteği (dnsmasq, Unbound, BIND RPZ) [bump:minor]

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -91,6 +91,10 @@ jobs:
           # This might be redundant if bump_version.py already did it.
           # Consider consolidating version logic if necessary. For now, assume generate_hosts.py is correct.
 
+      - name: Generate DNS format files
+        run: |
+          python scripts/generate_formats.py all
+
       - name: Backup filter files before release
         run: |
           # Yedekler klasörünü oluştur
@@ -166,7 +170,7 @@ jobs:
         run: |
           # Get new version from the output of the create_tag step
           VERSION=${{ steps.create_tag.outputs.version }}
-          gh release upload $VERSION tld_distribution.png active_inactive_distribution.png
+          gh release upload $VERSION tld_distribution.png active_inactive_distribution.png dnsmasq.conf unbound.conf rpz.zone
 
       - name: Add image links to Release Notes
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ pnpm-lock.yaml
 *.restore_safety_*
 *.tmp
 *.backup_temp
+
+# CI'da release asset olarak uretilen DNS format dosyalari
+dnsmasq.conf
+unbound.conf
+rpz.zone

--- a/README.en.md
+++ b/README.en.md
@@ -30,6 +30,45 @@
 - For DNS-based blockers, add the hosts.txt link to your adlists.
 - Works on browsers (Chrome, Firefox, Edge, Opera, Safari) and mobile apps (AdGuard, Blokada, DNS66, etc.).
 
+### DNS Resolver Formats
+
+Each release includes files for dnsmasq, Unbound, and BIND RPZ. Download from the [latest release](https://github.com/omerdduran/turk-adfilter/releases/latest).
+
+- **dnsmasq:**
+  ```bash
+  curl -o /etc/dnsmasq.d/turk-adfilter.conf https://github.com/omerdduran/turk-adfilter/releases/latest/download/dnsmasq.conf
+  sudo systemctl restart dnsmasq
+  ```
+
+- **Unbound:**
+  ```bash
+  curl -o /etc/unbound/turk-adfilter.conf https://github.com/omerdduran/turk-adfilter/releases/latest/download/unbound.conf
+  ```
+  Add to your `unbound.conf`:
+  ```
+  include: /etc/unbound/turk-adfilter.conf
+  ```
+  ```bash
+  sudo systemctl restart unbound
+  ```
+
+- **BIND (RPZ):**
+  ```bash
+  curl -o /etc/bind/zones/turk-adfilter.rpz https://github.com/omerdduran/turk-adfilter/releases/latest/download/rpz.zone
+  ```
+  Add to your `named.conf`:
+  ```
+  response-policy { zone "turk-adfilter.rpz"; };
+
+  zone "turk-adfilter.rpz" {
+      type master;
+      file "/etc/bind/zones/turk-adfilter.rpz";
+  };
+  ```
+  ```bash
+  sudo systemctl restart named
+  ```
+
 ## Contribution
 - You can suggest new domains or report issues via GitHub Issues or Pull Requests.
 - Only add Turkish ad, tracker, or harmful domains.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,49 @@
 - **Mobil (Android/iOS):** AdGuard, Blokada, DNS66 gibi uygulamalarda özel liste olarak ekleyin.
 - **Tarayıcılar:** Chrome, Firefox, Edge, Opera ve Safari'de ilgili reklam engelleyici eklentisiyle kullanılabilir.
 
+### DNS Çözümleyici Formatları
+
+Her release'de dnsmasq, Unbound ve BIND RPZ formatlarında dosyalar yayınlanır. [Son release](https://github.com/omerdduran/turk-adfilter/releases/latest) sayfasından indirebilirsiniz.
+
+- **dnsmasq:**
+  ```bash
+  # Dosyayı indirin
+  curl -o /etc/dnsmasq.d/turk-adfilter.conf https://github.com/omerdduran/turk-adfilter/releases/latest/download/dnsmasq.conf
+  # Servisi yeniden başlatın
+  sudo systemctl restart dnsmasq
+  ```
+
+- **Unbound:**
+  ```bash
+  # Dosyayı indirin
+  curl -o /etc/unbound/turk-adfilter.conf https://github.com/omerdduran/turk-adfilter/releases/latest/download/unbound.conf
+  ```
+  `unbound.conf` dosyanıza ekleyin:
+  ```
+  include: /etc/unbound/turk-adfilter.conf
+  ```
+  ```bash
+  sudo systemctl restart unbound
+  ```
+
+- **BIND (RPZ):**
+  ```bash
+  # Zone dosyasını indirin
+  curl -o /etc/bind/zones/turk-adfilter.rpz https://github.com/omerdduran/turk-adfilter/releases/latest/download/rpz.zone
+  ```
+  `named.conf` dosyanıza ekleyin:
+  ```
+  response-policy { zone "turk-adfilter.rpz"; };
+
+  zone "turk-adfilter.rpz" {
+      type master;
+      file "/etc/bind/zones/turk-adfilter.rpz";
+  };
+  ```
+  ```bash
+  sudo systemctl restart named
+  ```
+
 Detaylı kurulum ve dokümantasyon için: [Kurulum Rehberi](https://www.reklamsiz-turkiye.com/docs/kurulum)
 
 ## Desteklenen Platformlar

--- a/frontend/content/docs/kurulum.mdx
+++ b/frontend/content/docs/kurulum.mdx
@@ -50,6 +50,56 @@ description: Turk-AdFilter'ı farklı platformlarda nasıl kurabileceğinizi ö�
 > https://codeberg.org/omerdduran/turk-adfilter/raw/branch/main/hosts.txt
 > ```
 
+## DNS Çözümleyici Formatları
+
+Her release'de dnsmasq, Unbound ve BIND RPZ formatlarında dosyalar yayınlanır. [Son release](https://github.com/omerdduran/turk-adfilter/releases/latest) sayfasından indirebilirsiniz.
+
+### dnsmasq
+
+1. **Dosyayı İndirin**:
+```bash
+curl -o /etc/dnsmasq.d/turk-adfilter.conf https://github.com/omerdduran/turk-adfilter/releases/latest/download/dnsmasq.conf
+```
+2. **Servisi Yeniden Başlatın**:
+```bash
+sudo systemctl restart dnsmasq
+```
+
+### Unbound
+
+1. **Dosyayı İndirin**:
+```bash
+curl -o /etc/unbound/turk-adfilter.conf https://github.com/omerdduran/turk-adfilter/releases/latest/download/unbound.conf
+```
+2. **Yapılandırmaya Ekleyin**: `unbound.conf` dosyanıza şu satırı ekleyin:
+```
+include: /etc/unbound/turk-adfilter.conf
+```
+3. **Servisi Yeniden Başlatın**:
+```bash
+sudo systemctl restart unbound
+```
+
+### BIND (RPZ)
+
+1. **Zone Dosyasını İndirin**:
+```bash
+curl -o /etc/bind/zones/turk-adfilter.rpz https://github.com/omerdduran/turk-adfilter/releases/latest/download/rpz.zone
+```
+2. **Yapılandırmaya Ekleyin**: `named.conf` dosyanıza şu blokları ekleyin:
+```
+response-policy { zone "turk-adfilter.rpz"; };
+
+zone "turk-adfilter.rpz" {
+    type master;
+    file "/etc/bind/zones/turk-adfilter.rpz";
+};
+```
+3. **Servisi Yeniden Başlatın**:
+```bash
+sudo systemctl restart named
+```
+
 ## Mobil Cihazlarda Kullanım
 
 ### Android

--- a/scripts/generate_formats.py
+++ b/scripts/generate_formats.py
@@ -1,0 +1,106 @@
+import re
+import os
+import sys
+from datetime import datetime
+
+
+def extract_domains(input_path):
+    """
+    Extracts plain domain block rules from an AdBlock-style filter list.
+    Returns a sorted list of unique domains.
+    """
+    domains = set()
+    domain_pattern = re.compile(r"^\|\|([a-zA-Z0-9.-]+)\^$")
+
+    with open(input_path, 'r', encoding='utf-8') as infile:
+        for line in infile:
+            line = line.strip()
+            if not line or line.startswith('!'):
+                continue
+            match = domain_pattern.match(line)
+            if match:
+                domain = match.group(1)
+                if '.' in domain:
+                    domains.add(domain)
+
+    return sorted(domains)
+
+
+def generate_dnsmasq(domains, output_path):
+    """dnsmasq formatinda cikti uretir: address=/domain.com/"""
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write("# turk-adfilter - dnsmasq format\n")
+        f.write(f"# Generated: {datetime.now().strftime('%Y-%m-%d')}\n")
+        f.write(f"# Total domains: {len(domains)}\n")
+        f.write("# https://github.com/omerdduran/turk-adfilter\n")
+        f.write("\n")
+        for domain in domains:
+            f.write(f"address=/{domain}/\n")
+    print(f"Generated {output_path} with {len(domains)} domains (dnsmasq).")
+
+
+def generate_unbound(domains, output_path):
+    """Unbound DNS resolver formatinda cikti uretir."""
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write("# turk-adfilter - Unbound format\n")
+        f.write(f"# Generated: {datetime.now().strftime('%Y-%m-%d')}\n")
+        f.write(f"# Total domains: {len(domains)}\n")
+        f.write("# https://github.com/omerdduran/turk-adfilter\n")
+        f.write("#\n")
+        f.write("# Usage: include this file in your unbound.conf:\n")
+        f.write("#   include: /path/to/unbound.conf\n")
+        f.write("\n")
+        f.write("server:\n")
+        for domain in domains:
+            f.write(f'    local-zone: "{domain}" always_refuse\n')
+    print(f"Generated {output_path} with {len(domains)} domains (Unbound).")
+
+
+def generate_rpz(domains, output_path):
+    """BIND Response Policy Zone (RPZ) formatinda cikti uretir."""
+    serial = datetime.now().strftime('%Y%m%d01')
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write("; turk-adfilter - BIND RPZ format\n")
+        f.write(f"; Generated: {datetime.now().strftime('%Y-%m-%d')}\n")
+        f.write(f"; Total domains: {len(domains)}\n")
+        f.write("; https://github.com/omerdduran/turk-adfilter\n")
+        f.write(";\n")
+        f.write("; Usage: add this as a response-policy zone in named.conf:\n")
+        f.write(";   response-policy { zone \"turk-adfilter.rpz\"; };\n")
+        f.write("\n")
+        f.write("$TTL 300\n")
+        f.write(f"@ IN SOA localhost. root.localhost. {serial} 3600 600 604800 300\n")
+        f.write("  IN NS  localhost.\n")
+        f.write("\n")
+        for domain in domains:
+            f.write(f"{domain} CNAME .\n")
+            f.write(f"*.{domain} CNAME .\n")
+    print(f"Generated {output_path} with {len(domains)} domains (BIND RPZ).")
+
+
+def main():
+    script_dir = os.path.dirname(__file__)
+    root_dir = os.path.join(script_dir, '..')
+    input_path = os.path.join(root_dir, 'turk-adfilter.txt')
+
+    if not os.path.exists(input_path):
+        print(f"Error: {input_path} not found.")
+        sys.exit(1)
+
+    domains = extract_domains(input_path)
+    print(f"Extracted {len(domains)} unique domains from turk-adfilter.txt")
+
+    formats = sys.argv[1:] if len(sys.argv) > 1 else ['all']
+
+    if 'all' in formats or 'dnsmasq' in formats:
+        generate_dnsmasq(domains, os.path.join(root_dir, 'dnsmasq.conf'))
+
+    if 'all' in formats or 'unbound' in formats:
+        generate_unbound(domains, os.path.join(root_dir, 'unbound.conf'))
+
+    if 'all' in formats or 'rpz' in formats:
+        generate_rpz(domains, os.path.join(root_dir, 'rpz.zone'))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_generate_formats.py
+++ b/scripts/test_generate_formats.py
@@ -1,0 +1,170 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from generate_formats import extract_domains, generate_dnsmasq, generate_unbound, generate_rpz
+
+
+SAMPLE_FILTER = """\
+! Title: Test Filter
+! Version: 1.0.0
+||ads.example.com^
+||tracker.example.org^
+||zz-last.example.net^
+||aa-first.example.net^
+## element hiding rule (should be ignored)
+example.com##.ad-banner
+@@||exception.example.com^
+/regex-rule/
+||invalid^
+"""
+
+
+class TestExtractDomains(unittest.TestCase):
+    def setUp(self):
+        self.tmpfile = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False, encoding='utf-8')
+        self.tmpfile.write(SAMPLE_FILTER)
+        self.tmpfile.close()
+
+    def tearDown(self):
+        os.unlink(self.tmpfile.name)
+
+    def test_extracts_valid_domains(self):
+        domains = extract_domains(self.tmpfile.name)
+        self.assertIn('ads.example.com', domains)
+        self.assertIn('tracker.example.org', domains)
+
+    def test_ignores_comments(self):
+        domains = extract_domains(self.tmpfile.name)
+        self.assertTrue(all(not d.startswith('!') for d in domains))
+
+    def test_ignores_cosmetic_rules(self):
+        domains = extract_domains(self.tmpfile.name)
+        self.assertNotIn('example.com##.ad-banner', domains)
+
+    def test_ignores_exception_rules(self):
+        domains = extract_domains(self.tmpfile.name)
+        self.assertNotIn('exception.example.com', domains)
+
+    def test_ignores_domains_without_dot(self):
+        domains = extract_domains(self.tmpfile.name)
+        self.assertNotIn('invalid', domains)
+
+    def test_returns_sorted(self):
+        domains = extract_domains(self.tmpfile.name)
+        self.assertEqual(domains, sorted(domains))
+
+    def test_correct_count(self):
+        domains = extract_domains(self.tmpfile.name)
+        self.assertEqual(len(domains), 4)
+
+
+class TestGenerateDnsmasq(unittest.TestCase):
+    def test_format(self):
+        domains = ['ads.example.com', 'tracker.example.org']
+        outfile = tempfile.NamedTemporaryFile(mode='w', suffix='.conf', delete=False)
+        outfile.close()
+        generate_dnsmasq(domains, outfile.name)
+        with open(outfile.name, 'r') as f:
+            content = f.read()
+        os.unlink(outfile.name)
+        self.assertIn('address=/ads.example.com/', content)
+        self.assertIn('address=/tracker.example.org/', content)
+        self.assertIn('Total domains: 2', content)
+
+    def test_no_extra_lines(self):
+        domains = ['one.example.com']
+        outfile = tempfile.NamedTemporaryFile(mode='w', suffix='.conf', delete=False)
+        outfile.close()
+        generate_dnsmasq(domains, outfile.name)
+        with open(outfile.name, 'r') as f:
+            lines = [l for l in f.readlines() if l.strip() and not l.startswith('#')]
+        os.unlink(outfile.name)
+        self.assertEqual(len(lines), 1)
+
+
+class TestGenerateUnbound(unittest.TestCase):
+    def test_format(self):
+        domains = ['ads.example.com', 'tracker.example.org']
+        outfile = tempfile.NamedTemporaryFile(mode='w', suffix='.conf', delete=False)
+        outfile.close()
+        generate_unbound(domains, outfile.name)
+        with open(outfile.name, 'r') as f:
+            content = f.read()
+        os.unlink(outfile.name)
+        self.assertIn('local-zone: "ads.example.com" always_refuse', content)
+        self.assertIn('local-zone: "tracker.example.org" always_refuse', content)
+        self.assertIn('server:', content)
+
+    def test_indentation(self):
+        domains = ['ads.example.com']
+        outfile = tempfile.NamedTemporaryFile(mode='w', suffix='.conf', delete=False)
+        outfile.close()
+        generate_unbound(domains, outfile.name)
+        with open(outfile.name, 'r') as f:
+            lines = f.readlines()
+        os.unlink(outfile.name)
+        zone_lines = [l for l in lines if 'local-zone' in l]
+        for line in zone_lines:
+            self.assertTrue(line.startswith('    '))
+
+
+class TestGenerateRpz(unittest.TestCase):
+    def test_format(self):
+        domains = ['ads.example.com']
+        outfile = tempfile.NamedTemporaryFile(mode='w', suffix='.zone', delete=False)
+        outfile.close()
+        generate_rpz(domains, outfile.name)
+        with open(outfile.name, 'r') as f:
+            content = f.read()
+        os.unlink(outfile.name)
+        self.assertIn('ads.example.com CNAME .', content)
+        self.assertIn('*.ads.example.com CNAME .', content)
+
+    def test_soa_header(self):
+        domains = ['ads.example.com']
+        outfile = tempfile.NamedTemporaryFile(mode='w', suffix='.zone', delete=False)
+        outfile.close()
+        generate_rpz(domains, outfile.name)
+        with open(outfile.name, 'r') as f:
+            content = f.read()
+        os.unlink(outfile.name)
+        self.assertIn('$TTL 300', content)
+        self.assertIn('IN SOA localhost.', content)
+        self.assertIn('IN NS  localhost.', content)
+
+    def test_wildcard_for_each_domain(self):
+        domains = ['a.example.com', 'b.example.org']
+        outfile = tempfile.NamedTemporaryFile(mode='w', suffix='.zone', delete=False)
+        outfile.close()
+        generate_rpz(domains, outfile.name)
+        with open(outfile.name, 'r') as f:
+            content = f.read()
+        os.unlink(outfile.name)
+        self.assertIn('*.a.example.com CNAME .', content)
+        self.assertIn('*.b.example.org CNAME .', content)
+
+
+class TestHostsConsistency(unittest.TestCase):
+    """Domain count from generate_formats should match hosts.txt"""
+
+    def test_domain_count_matches_hosts(self):
+        script_dir = os.path.dirname(__file__)
+        root = os.path.join(script_dir, '..')
+        filter_path = os.path.join(root, 'turk-adfilter.txt')
+        hosts_path = os.path.join(root, 'hosts.txt')
+
+        if not os.path.exists(filter_path) or not os.path.exists(hosts_path):
+            self.skipTest('turk-adfilter.txt or hosts.txt not found')
+
+        domains = extract_domains(filter_path)
+        with open(hosts_path, 'r') as f:
+            hosts_count = sum(1 for line in f if line.strip() and not line.startswith('#'))
+
+        self.assertEqual(len(domains), hosts_count)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/turk-adfilter.txt
+++ b/turk-adfilter.txt
@@ -3,7 +3,7 @@
 ! Description: Türkiye merkezli reklam, izleyici ve zararlı içerik sağlayıcılarını engelleyen topluluk tabanlı bir filtre listesidir. AdGuard, uBlock Origin ve benzeri servislerde kullanılabilir.
 ! This is a community-driven blocklist to block Turkish ad, tracker, and malicious content providers. Usable with Pihole, AdGuard, uBlock Origin, etc.
 !
-! Version: 1.6.0 – 26.02.2026
+! Version: 1.7.0 – 23.03.2026
 ! Maintainer: github.com/omerdduran
 !
 ! ---------------------------------------------------------


### PR DESCRIPTION
## Özet

- turk-adfilter.txt'den dnsmasq, Unbound ve BIND RPZ formatlarında dosya üreten `generate_formats.py` script'i eklendi
- Release pipeline'a format üretimi ve asset upload entegre edildi
- README (TR + EN) ve frontend dokümantasyonuna kurulum talimatları eklendi

## Test plan

- [x] `python scripts/generate_formats.py all` ile 3 dosya üretildiği doğrulanır
- [x] `python -m unittest scripts/test_generate_formats.py` ile 15 test geçer
- [x] PR merge sonrası version-bump workflow format dosyalarını release'e ekler